### PR TITLE
refactor: remove deprecated rule and use the new one

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = {
     ],
     'scss/at-extend-no-missing-placeholder': true,
     'scss/at-function-pattern': '^[_-]?[a-z]+([a-z0-9-]+[a-z0-9]+)?$',
-    'scss/at-import-partial-extension': 'never',
+    'scss/load-partial-extension': 'never',
     'scss/at-mixin-pattern': '^[_-]?[a-z]+([a-z0-9-]+[a-z0-9]+)?$',
     'scss/at-rule-no-unknown': true,
     'scss/comment-no-empty': null,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "stylelint-order": "^6.0.4"
   },
   "devDependencies": {
-    "prettier": "^3.3.2"
+    "prettier": "^3.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,10 +64,10 @@ postcss@^8.4.32:
     picocolors "^1.0.1"
     source-map-js "^1.2.0"
 
-prettier@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
-  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 source-map-js@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
remove deprecated rule `scss/at-import-partial-extension` and use `load-partial-extension` instead

- **build: upgrade dependencies**
- **refactor: remove deprecated rule and use the new one**
